### PR TITLE
Terraform fmt

### DIFF
--- a/terraform/modules/vpc/aws/main.tf
+++ b/terraform/modules/vpc/aws/main.tf
@@ -24,15 +24,15 @@ locals {
 resource "aws_vpc" "this" {
   count = local.create_vpc ? 1 : 0
 
-  cidr_block           = var.vpc_cidr
-  instance_tenancy           = var.instance_tenancy
+  cidr_block                       = var.vpc_cidr
+  instance_tenancy                 = var.instance_tenancy
   enable_dns_hostnames             = var.enable_dns_hostnames
-  enable_dns_support           = var.enable_dns_support
+  enable_dns_support               = var.enable_dns_support
   enable_classiclink               = var.enable_classiclink
   enable_classiclink_dns_support   = var.enable_classiclink_dns_support
   assign_generated_ipv6_cidr_block = var.enable_ipv6
 
-    tags = merge(
+  tags = merge(
     { "Name" = var.name },
     var.tags,
     var.vpc_tags,


### PR DESCRIPTION
Terraform fmt was launched and corrected the formatting in this pull request:
```
modules/vpc/aws/main.tf
--- old/modules/vpc/aws/main.tf
+++ new/modules/vpc/aws/main.tf
@@ -24,15 +24,15 @@
 resource "aws_vpc" "this" {
   count = local.create_vpc ? 1 : 0
 
-  cidr_block           = var.vpc_cidr
-  instance_tenancy           = var.instance_tenancy
+  cidr_block                       = var.vpc_cidr
+  instance_tenancy                 = var.instance_tenancy
   enable_dns_hostnames             = var.enable_dns_hostnames
-  enable_dns_support           = var.enable_dns_support
+  enable_dns_support               = var.enable_dns_support
   enable_classiclink               = var.enable_classiclink
   enable_classiclink_dns_support   = var.enable_classiclink_dns_support
   assign_generated_ipv6_cidr_block = var.enable_ipv6
 
-    tags = merge(
+  tags = merge(
     { "Name" = var.name },
     var.tags,
     var.vpc_tags,

```